### PR TITLE
Support bleak for BLE communication

### DIFF
--- a/custom_components/basestation/const.py
+++ b/custom_components/basestation/const.py
@@ -1,6 +1,3 @@
 """Constants for the Valve Index Basestation integration."""
 
 DOMAIN = "basestation"
-PWR_CHARACTERISTIC = "00001525-1212-efde-1523-785feabcd124"
-PWR_ON = bytearray([0x01])
-PWR_STANDBY = bytearray([0x00])

--- a/custom_components/basestation/const.py
+++ b/custom_components/basestation/const.py
@@ -1,3 +1,6 @@
 """Constants for the Valve Index Basestation integration."""
 
 DOMAIN = "basestation"
+PWR_CHARACTERISTIC = "00001525-1212-EFDE-1523-785FEABCD124"
+PWR_ON = b"\x01"
+PWR_STANDBY = b"\x00"

--- a/custom_components/basestation/const.py
+++ b/custom_components/basestation/const.py
@@ -1,3 +1,6 @@
 """Constants for the Valve Index Basestation integration."""
 
 DOMAIN = "basestation"
+PWR_CHARACTERISTIC = "00001525-1212-efde-1523-785feabcd124"
+PWR_ON = bytearray([0x01])
+PWR_STANDBY = bytearray([0x00])

--- a/custom_components/basestation/manifest.json
+++ b/custom_components/basestation/manifest.json
@@ -5,9 +5,7 @@
   "config_flow": false,
   "documentation": "https://github.com/jariz/homeassistant-basestation",
   "issue_tracker": "https://github.com/jariz/homeassistant-basestation/issues",
-  "requirements": [
-    "basestation==0.0.4"
-  ],
+  "requirements": [],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -4,9 +4,11 @@ from bleak import BleakClient
 
 from homeassistant.components.switch import SwitchEntity
 
-PWR_CHARACTERISTIC = "00001525-1212-efde-1523-785feabcd124"
-PWR_ON = bytearray([0x01])
-PWR_STANDBY = bytearray([0x00])
+from .const import (
+    PWR_CHARACTERISTIC,
+    PWR_ON,
+    PWR_STANDBY,
+)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
@@ -37,15 +39,15 @@ class BasestationSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        self._device.connect()
-        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_ON)
-        self._device.disconnect()
+        await self._device.connect()
+        await self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_ON)
+        await self._device.disconnect()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        self._device.connect()
-        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_STANDBY)
-        self._device.disconnect()
+        await self._device.connect()
+        await self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_STANDBY)
+        await self._device.disconnect()
 
     @property
     def name(self):
@@ -57,6 +59,6 @@ class BasestationSwitch(SwitchEntity):
 
     def update(self):
         """Fetch new state data for the sensor."""
-        self._device.connect()
-        self._is_on = self._device.is_turned_on()
-        self._device.disconnect()
+        await self._device.connect()
+        self._is_on = await self._device.read_gatt_char(PWR_CHARACTERISTIC) != PWR_STANDBY
+        await self._device.disconnect()

--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -4,7 +4,9 @@ from bleak import BleakClient
 
 from homeassistant.components.switch import SwitchEntity
 
-import const
+PWR_CHARACTERISTIC = "00001525-1212-efde-1523-785feabcd124"
+PWR_ON = bytearray([0x01])
+PWR_STANDBY = bytearray([0x00])
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
@@ -36,13 +38,13 @@ class BasestationSwitch(SwitchEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._device.connect()
-        self._device.write_gatt_char(const.PWR_CHARACTERISTIC, const.PWR_ON)
+        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_ON)
         self._device.disconnect()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._device.connect()
-        self._device.write_gatt_char(const.PWR_CHARACTERISTIC, const.PWR_STANDBY)
+        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_STANDBY)
         self._device.disconnect()
 
     @property

--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -39,15 +39,15 @@ class BasestationSwitch(SwitchEntity):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        await self._device.connect()
-        await self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_ON)
-        await self._device.disconnect()
+        self._device.connect()
+        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_ON)
+        self._device.disconnect()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
-        await self._device.connect()
-        await self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_STANDBY)
-        await self._device.disconnect()
+        self._device.connect()
+        self._device.write_gatt_char(PWR_CHARACTERISTIC, PWR_STANDBY)
+        self._device.disconnect()
 
     @property
     def name(self):
@@ -59,6 +59,6 @@ class BasestationSwitch(SwitchEntity):
 
     def update(self):
         """Fetch new state data for the sensor."""
-        await self._device.connect()
-        self._is_on = await self._device.read_gatt_char(PWR_CHARACTERISTIC) != PWR_STANDBY
-        await self._device.disconnect()
+        self._device.connect()
+        self._is_on = self._device.read_gatt_char(PWR_CHARACTERISTIC) != PWR_STANDBY
+        self._device.disconnect()

--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -1,15 +1,16 @@
 """The basestation switch."""
 
-from basestation.device import BasestationDevice
+from bleak import BleakClient
 
 from homeassistant.components.switch import SwitchEntity
 
+import const
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the sensor platform."""
     mac = config.get("mac")
     name = config.get("name")
-    device = BasestationDevice(mac)
+    device = BleakClient(mac)
     add_entities([BasestationSwitch(device, name)])
 
 
@@ -35,13 +36,13 @@ class BasestationSwitch(SwitchEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._device.connect()
-        self._device.turn_on()
+        self._device.write_gatt_char(const.PWR_CHARACTERISTIC, const.PWR_ON)
         self._device.disconnect()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._device.connect()
-        self._device.turn_off()
+        self._device.write_gatt_char(const.PWR_CHARACTERISTIC, const.PWR_STANDBY)
         self._device.disconnect()
 
     @property


### PR DESCRIPTION
Since the newer versions of Home Assistant don't support bluepy anymore I migrated this component to bleak.
1. You need to remove the default Bluetooth integration - both from the integrations screen or if you have manually added "bluetooth:" row in configuration.yaml. I didn't manage to get it working while having this default Bluetooth integration enabled but your mileage might vary.
2. I had to restart the host machine and played a bit with "bluetoothctl power on", "bluetoothctl power off", "bluetoothctl scan on" and "bluetoothctl scan off" commands in the terminal because I was getting some strange errors. Please verify on your end if everything is working since this might be related to my machine only.
3.  For now I can only turn the base stations one by one - if I try to turn both of them on/off at the same time I get an error message. My workaround for this is having a script in home assistant which turns on/off the base stations but with a 5 second delay between the actions. 

There might be a better way to migrate to bleak but this is my workaround since I really need a working way to communicate with my base stations. I hope this is of some help!