### PR TITLE
Resolve #12 - Does not work with version 2024.1.0

### DIFF
--- a/custom_components/basestation/switch.py
+++ b/custom_components/basestation/switch.py
@@ -72,4 +72,4 @@ class BasestationSwitch(SwitchEntity):
             self._is_on = await client.read_gatt_char(PWR_CHARACTERISTIC) != PWR_STANDBY
 
     def get_ble_device(self):
-        return bluetooth.async_ble_device_from_address(self._hass, self._mac)
+        return bluetooth.async_ble_device_from_address(self._hass, str(self._mac))


### PR DESCRIPTION
This seems to be all that is required to make it work again with the newer version of Home Assistant. I am running this myself at the moment and everything seems to work, using a Bluetooth proxy :)